### PR TITLE
prettier関連のnpmをアンインストールし、設定ファイルも削除

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "es2021": true,
     "node": true
   },
-  "extends": ["standard", "prettier"],
+  "extends": ["standard"],
   "parserOptions": {
     "ecmaVersion": "latest"
   },

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,0 @@
-"prettier-config-standard"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,10 @@
       "license": "ISC",
       "devDependencies": {
         "eslint": "^8.20.0",
-        "eslint-config-prettier": "^8.5.0",
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-n": "^15.2.4",
-        "eslint-plugin-promise": "^6.0.0",
-        "prettier": "2.7.1",
-        "prettier-config-standard": "^5.0.0"
+        "eslint-plugin-promise": "^6.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -446,18 +443,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "bin": {
-        "eslint-config-prettier": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-config-standard": {
@@ -1549,30 +1534,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-config-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-config-standard/-/prettier-config-standard-5.0.0.tgz",
-      "integrity": "sha512-QK252QwCxlsak8Zx+rPKZU31UdbRcu9iUk9X1ONYtLSO221OgvV9TlKoTf6iPDZtvF3vE2mkgzFIEgSUcGELSQ==",
-      "dev": true,
-      "peerDependencies": {
-        "prettier": "^2.4.0"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -2240,13 +2201,6 @@
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       }
-    },
-    "eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
     },
     "eslint-config-standard": {
       "version": "17.0.0",
@@ -3040,19 +2994,6 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
-    },
-    "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true
-    },
-    "prettier-config-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-config-standard/-/prettier-config-standard-5.0.0.tgz",
-      "integrity": "sha512-QK252QwCxlsak8Zx+rPKZU31UdbRcu9iUk9X1ONYtLSO221OgvV9TlKoTf6iPDZtvF3vE2mkgzFIEgSUcGELSQ==",
-      "dev": true,
-      "requires": {}
     },
     "punycode": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,9 @@
   "homepage": "https://github.com/Saki-htr/fjord-choice#readme",
   "devDependencies": {
     "eslint": "^8.20.0",
-    "eslint-config-prettier": "^8.5.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-n": "^15.2.4",
-    "eslint-plugin-promise": "^6.0.0",
-    "prettier": "2.7.1",
-    "prettier-config-standard": "^5.0.0"
+    "eslint-plugin-promise": "^6.0.0"
   }
 }


### PR DESCRIPTION
## issue
- #65 

## 削除理由
JS系フレームワークは使わないため、prettierはやはり入れないことにした。
「ファーストリリースで使わなくても、いつか使うかも」と思い入れることにしたが、「いつか使うかも」という理由でライブラリを入れると、どんどんライブラリが増え、使わないライブラリを管理する手間は無駄なので、フロントエンドをVue.jsやReactにする時に導入を再度検討する。


## 関連
- #59 
- #62 