### PR TITLE
PRのupdateの処理を書いた

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -11,6 +11,5 @@ class HomeController < ApplicationController
     AssignedIssue.update
     ReviewRequestedPullRequest.create
     ReviewRequestedPullRequest.update
-    # テスト
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,6 +8,9 @@ class HomeController < ApplicationController
 
   def index
     AssignedIssue.create
+    AssignedIssue.update
     ReviewRequestedPullRequest.create
+    ReviewRequestedPullRequest.update
+    # テスト
   end
 end

--- a/app/models/assigned_issue.rb
+++ b/app/models/assigned_issue.rb
@@ -40,5 +40,29 @@ class AssignedIssue < ApplicationRecord
       end
     end
     # rubocop:enable Metrics/MethodLength
+
+    def api_request_for_update
+      # client.issue('fjordllc/bootcamp', '5381')
+      AssignedIssue.pluck(:number).map do |number|
+        client.issue('fjordllc/bootcamp', number)
+      end
+    end
+
+    def update
+      api_request_for_update.each do |issue|
+        assigned_issue = AssignedIssue.find_by(number: issue[:number])
+
+        issue[:labels].each do |label|
+          next if label[:name].to_i.zero?
+
+          assigned_issue.point = label[:name].to_i
+        end
+        issue[:assignees].each do |assignee|
+          assigned_issue.assignees = []
+          assigned_issue.assignees << assignee[:id]
+        end
+        assigned_issue.save!
+      end
+    end
   end
 end

--- a/app/models/review_requested_pull_request.rb
+++ b/app/models/review_requested_pull_request.rb
@@ -41,5 +41,28 @@ class ReviewRequestedPullRequest < ApplicationRecord
       end
     end
     # rubocop:enable Metrics/MethodLength
+
+    def api_request_for_update
+      # client.issue('fjordllc/bootcamp', '5381')
+      ReviewRequestedPullRequest.pluck(:number).map do |number|
+        client.pull_request('fjordllc/bootcamp', number)
+      end
+    end
+
+    def update
+      api_request_for_update.each do |pull|
+        pull_request = ReviewRequestedPullRequest.find_by(number: pull[:number])
+        pull_request.title = pull[:title]
+        if pull[:requested_reviewers].empty?
+          pull_request.reviewers = []
+        else
+          pull[:requested_reviewers].each do |reviewer|
+            pull_request.reviewers = []
+            pull_request.reviewers << reviewer[:id]
+          end
+        end
+        pull_request.save!
+      end
+    end
   end
 end

--- a/app/models/review_requested_pull_request.rb
+++ b/app/models/review_requested_pull_request.rb
@@ -11,17 +11,16 @@ class ReviewRequestedPullRequest < ApplicationRecord
                           client_secret: ENV['GITHUB_SECRET'])
     end
 
-    def api_request
+    def api_request_for_create
       client.pull_requests('fjordllc/bootcamp', { state: 'open', per_page: 100 })
     end
 
     def delete_release_branch
-      api_request.delete_if do |pull|
-        pull[:labels][0][:name] == 'release' unless pull[:labels].empty? # nil避け
+      api_request_for_create.delete_if do |pull|
+        pull[:labels][0][:name] == 'release' unless pull[:labels].empty?
       end
     end
 
-    # rubocop:disable Metrics/MethodLength
     def create
       delete_release_branch.each do |pull|
         next if ReviewRequestedPullRequest.exists?(number: pull[:number])
@@ -29,21 +28,12 @@ class ReviewRequestedPullRequest < ApplicationRecord
         pull_request = ReviewRequestedPullRequest.new
         pull_request.number = pull[:number]
         pull_request.title = pull[:title]
-        if pull[:requested_reviewers].empty?
-          pull_request.reviewers = []
-        else
-          pull[:requested_reviewers].each do |reviewer|
-            pull_request.reviewers = []
-            pull_request.reviewers << reviewer[:id]
-          end
-        end
+        pull_request.reviewers = pull[:requested_reviewers].map(&:id)
         pull_request.save!
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     def api_request_for_update
-      # client.issue('fjordllc/bootcamp', '5381')
       ReviewRequestedPullRequest.pluck(:number).map do |number|
         client.pull_request('fjordllc/bootcamp', number)
       end
@@ -53,14 +43,7 @@ class ReviewRequestedPullRequest < ApplicationRecord
       api_request_for_update.each do |pull|
         pull_request = ReviewRequestedPullRequest.find_by(number: pull[:number])
         pull_request.title = pull[:title]
-        if pull[:requested_reviewers].empty?
-          pull_request.reviewers = []
-        else
-          pull[:requested_reviewers].each do |reviewer|
-            pull_request.reviewers = []
-            pull_request.reviewers << reviewer[:id]
-          end
-        end
+        pull_request.reviewers = pull[:requested_reviewers].map(&:id)
         pull_request.save!
       end
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module FjordChoice
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Tokyo'
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.


### PR DESCRIPTION
## issue
- #91 

## やったこと
- 既にDBに保存されているのissue/PRのカラムを、APIリクエストして更新する処理を追加
- リファクタリングをした
  - assigneeとrequested_reviewersが空の場合、デフォルトで`[]`が入るようになっているので、「からの場合空配列を代入する」処理を削除
  - mapメソッドとぼっち演算子を使ってリファクタリング
   