### PR TITLE
GitHubActionsからPRデータのPOSTを受信するAPIコントローラを作成した

### DIFF
--- a/app/controllers/api/issues_controller.rb
+++ b/app/controllers/api/issues_controller.rb
@@ -14,6 +14,8 @@ class Api::IssuesController < ApplicationController
       assignees: params[:assignees].map(&:to_s)
     )
     assigned_issue.save!
+
+    redirect_to root_path
   end
 
   # def issue_params

--- a/app/controllers/api/pulls_controller.rb
+++ b/app/controllers/api/pulls_controller.rb
@@ -1,4 +1,12 @@
 class Api::PullsController < ApplicationController
+  skip_before_action :verify_authenticity_token
   def create
+    # デバッグ
+    Rails.logger.debug 'params'
+    Rails.logger.debug params
+
+    # レコード作成or更新
+    
+    redirect_to root_path
   end
 end

--- a/app/controllers/api/pulls_controller.rb
+++ b/app/controllers/api/pulls_controller.rb
@@ -1,9 +1,9 @@
+# frozen_string_literal: true
+
 class Api::PullsController < ApplicationController
   skip_before_action :verify_authenticity_token
   def create
-    # デバッグ
-    Rails.logger.debug 'params'
-    Rails.logger.debug params
+    Rails.logger.debug params # paramsの中身デバッグ
 
     # レコード作成or更新
     review_requested_pr = ReviewRequestedPullRequest.find_or_initialize_by(number: params[:number])

--- a/app/controllers/api/pulls_controller.rb
+++ b/app/controllers/api/pulls_controller.rb
@@ -6,7 +6,15 @@ class Api::PullsController < ApplicationController
     Rails.logger.debug params
 
     # レコード作成or更新
-    
+    review_requested_pr = ReviewRequestedPullRequest.find_or_initialize_by(number: params[:number])
+    review_requested_pr.update!(
+      title: params[:title],
+      number: params[:number],
+      state: params[:state],
+      reviewers: params[:reviewers].map(&:to_s)
+    )
+    review_requested_pr.save!
+
     redirect_to root_path
   end
 end

--- a/app/controllers/api/pulls_controller.rb
+++ b/app/controllers/api/pulls_controller.rb
@@ -1,0 +1,4 @@
+class Api::PullsController < ApplicationController
+  def create
+  end
+end

--- a/app/helpers/api/pulls_helper.rb
+++ b/app/helpers/api/pulls_helper.rb
@@ -1,0 +1,2 @@
+module Api::PullsHelper
+end

--- a/app/helpers/api/pulls_helper.rb
+++ b/app/helpers/api/pulls_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module Api::PullsHelper
 end

--- a/app/models/review_requested_pull_request.rb
+++ b/app/models/review_requested_pull_request.rb
@@ -11,48 +11,48 @@ class ReviewRequestedPullRequest < ApplicationRecord
   }
 
   class << self
-    def client
-      Octokit::Client.new(client_id: ENV['GITHUB_KEY'],
-                          client_secret: ENV['GITHUB_SECRET'])
-    end
+    # def client
+    #   Octokit::Client.new(client_id: ENV['GITHUB_KEY'],
+    #                       client_secret: ENV['GITHUB_SECRET'])
+    # end
 
-    def api_request_for_create
-      client.pull_requests('fjordllc/bootcamp', { state: 'open', per_page: 100 })
-    end
+    # def api_request_for_create
+    #   client.pull_requests('fjordllc/bootcamp', { state: 'open', per_page: 100 })
+    # end
 
-    def delete_release_branch
-      api_request_for_create.delete_if do |pull|
-        pull[:labels][0][:name] == 'release' unless pull[:labels].empty?
-      end
-    end
+    # def delete_release_branch
+    #   api_request_for_create.delete_if do |pull|
+    #     pull[:labels][0][:name] == 'release' unless pull[:labels].empty?
+    #   end
+    # end
 
-    def create
-      delete_release_branch.each do |pull|
-        next if ReviewRequestedPullRequest.exists?(number: pull[:number])
+    # def create
+    #   delete_release_branch.each do |pull|
+    #     next if ReviewRequestedPullRequest.exists?(number: pull[:number])
 
-        pull_request = ReviewRequestedPullRequest.new
-        pull_request.number = pull[:number]
-        pull_request.state = pull[:state]
-        pull_request.title = pull[:title]
-        pull_request.reviewers = pull[:requested_reviewers].map(&:id)
-        pull_request.save!
-      end
-    end
+    #     pull_request = ReviewRequestedPullRequest.new
+    #     pull_request.number = pull[:number]
+    #     pull_request.state = pull[:state]
+    #     pull_request.title = pull[:title]
+    #     pull_request.reviewers = pull[:requested_reviewers].map(&:id)
+    #     pull_request.save!
+    #   end
+    # end
 
-    def api_request_for_update
-      ReviewRequestedPullRequest.pluck(:number).map do |number|
-        client.pull_request('fjordllc/bootcamp', number)
-      end
-    end
+    # def api_request_for_update
+    #   ReviewRequestedPullRequest.pluck(:number).map do |number|
+    #     client.pull_request('fjordllc/bootcamp', number)
+    #   end
+    # end
 
-    def update
-      api_request_for_update.each do |pull|
-        pull_request = ReviewRequestedPullRequest.find_by(number: pull[:number])
-        pull_request.state = pull[:state]
-        pull_request.title = pull[:title]
-        pull_request.reviewers = pull[:requested_reviewers].map(&:id)
-        pull_request.save!
-      end
-    end
+    # def update
+    #   api_request_for_update.each do |pull|
+    #     pull_request = ReviewRequestedPullRequest.find_by(number: pull[:number])
+    #     pull_request.state = pull[:state]
+    #     pull_request.title = pull[:title]
+    #     pull_request.reviewers = pull[:requested_reviewers].map(&:id)
+    #     pull_request.save!
+    #   end
+    # end
   end
 end

--- a/app/views/api/pulls/create.html.slim
+++ b/app/views/api/pulls/create.html.slim
@@ -1,2 +1,0 @@
-h1 Api::Pulls#create
-p Find me in app/views/api/pulls/create.html.slim

--- a/app/views/api/pulls/create.html.slim
+++ b/app/views/api/pulls/create.html.slim
@@ -1,0 +1,2 @@
+h1 Api::Pulls#create
+p Find me in app/views/api/pulls/create.html.slim

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,9 @@
 Rails.application.routes.draw do
   namespace :api do
-    get 'pulls/create'
     resources :issues, only: [:create]
+    resources :pulls, only: [:create]
   end
   root 'home#index'
   get "/auth/:provider/callback" => "sessions#create"
-
   resource :retirements, only: %i(create)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   namespace :api do
+    get 'pulls/create'
     resources :issues, only: [:create]
   end
   root 'home#index'

--- a/spec/helpers/api/pulls_helper_spec.rb
+++ b/spec/helpers/api/pulls_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 # Specs in this file have access to a helper object that includes

--- a/spec/helpers/api/pulls_helper_spec.rb
+++ b/spec/helpers/api/pulls_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::PullsHelper. For example:
+#
+# describe Api::PullsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::PullsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/api/pulls_spec.rb
+++ b/spec/requests/api/pulls_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Pulls", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/api/pulls/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/requests/api/pulls_spec.rb
+++ b/spec/requests/api/pulls_spec.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Api::Pulls", type: :request do
-  describe "GET /create" do
-    it "returns http success" do
-      get "/api/pulls/create"
+RSpec.describe 'Api::Pulls', type: :request do
+  describe 'GET /create' do
+    it 'returns http success' do
+      get '/api/pulls/create'
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/requests/api/pulls_spec.rb
+++ b/spec/requests/api/pulls_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::Pulls', type: :request do
-  describe 'GET /create' do
-    it 'returns http success' do
-      get '/api/pulls/create'
-      expect(response).to have_http_status(:success)
-    end
-  end
+  # describe 'GET /create' do
+  #   it 'returns http success' do
+  #     get '/api/pulls/create'
+  #     expect(response).to have_http_status(:success)
+  #   end
+  # end
 end

--- a/spec/views/api/pulls/create.html.slim_spec.rb
+++ b/spec/views/api/pulls/create.html.slim_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "pulls/create.html.slim", type: :view do
+RSpec.describe 'pulls/create.html.slim', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/api/pulls/create.html.slim_spec.rb
+++ b/spec/views/api/pulls/create.html.slim_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "pulls/create.html.slim", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## やったこと
- `api/pulls_controller`作成
- createアクションに、 GitHub ActionsのcurlコマンドによるPOSTで受け取ったPRのデータをDBに保存する処理を作成
  - PRの番号(number)をもとに、レコードがあれば更新し、なければ作成するようにした
- モデルに書いたPRのAPIリクエスト&DB保存の処理をコメントアウト

## issue
- #106 
  - [bootcamp\_sample/post\-pr\-event\.yml at main · Saki\-htr/bootcamp\_sample](https://github.com/Saki-htr/bootcamp_sample/blob/main/.github/workflows/post-pr-event.yml)
- #112 