### PR TITLE
認証が失敗した時とキャンセルした時のflashメッセージが同じになので、処理を分けた

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,12 @@
 class SessionsController < ApplicationController
   def create
     user = User.find_or_create_from_auth_hash!(request.env['omniauth.auth'])
-    session[:user_id] = user.id
+    if user
+      session[:user_id] = user.id
+      flash[:notice] = 'ログインしました'
+    else
+      flash[:notice] = '失敗しました'
+    end
     redirect_to root_path, notice: 'メンバーに追加されました'
   end
 


### PR DESCRIPTION
## issue
- #159 