### PR TITLE
コードレビューに基づき修正した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,6 @@ gem 'sassc-rails'
 
 gem 'bulma-rails', '~> 0.9.3'
 gem 'meta-tags'
-gem 'octokit', '~> 4.0'
 gem 'omniauth'
 gem 'omniauth-github'
 gem 'omniauth-rails_csrf_protection'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,9 +173,6 @@ GEM
       rack (>= 1.2, < 3)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
-    octokit (4.25.1)
-      faraday (>= 1, < 3)
-      sawyer (~> 0.9)
     omniauth (2.1.0)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
@@ -284,9 +281,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sawyer (0.9.2)
-      addressable (>= 2.3.5)
-      faraday (>= 0.17.3, < 3)
     selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -362,7 +356,6 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   meta-tags
-  octokit (~> 4.0)
   omniauth
   omniauth-github
   omniauth-rails_csrf_protection

--- a/app/controllers/api/issues_controller.rb
+++ b/app/controllers/api/issues_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class API::IssuesController < ApplicationController
-  protect_from_forgery except: :create
+class API::IssuesController < APIController
   before_action :authenticate, only: [:create]
 
   def create

--- a/app/controllers/api/pulls_controller.rb
+++ b/app/controllers/api/pulls_controller.rb
@@ -4,12 +4,8 @@ class API::PullsController < APIController
   before_action :authenticate, only: [:create]
 
   def create
-    pull_request = PullRequest.find_or_create_by(number: pull_params[:number])
-    if pull_request.update!(pull_params)
-      head :created
-    else
-      head :unprocessable_entity
-    end
+    pull_request = PullRequest.upsert(pull_params, unique_by: :number)
+    head :created
   end
 
   private

--- a/app/controllers/api/pulls_controller.rb
+++ b/app/controllers/api/pulls_controller.rb
@@ -4,7 +4,9 @@ class API::PullsController < APIController
   before_action :authenticate, only: [:create]
 
   def create
+    # rubocop:disable Rails/SkipsModelValidations
     PullRequest.upsert(pull_params, unique_by: :number)
+    # rubocop:enable Rails/SkipsModelValidations
     head :created
   end
 

--- a/app/controllers/api/pulls_controller.rb
+++ b/app/controllers/api/pulls_controller.rb
@@ -4,10 +4,12 @@ class API::PullsController < APIController
   before_action :authenticate, only: [:create]
 
   def create
-    # rubocop:disable Rails/SkipsModelValidations
-    PullRequest.upsert(pull_params, unique_by: :number)
-    # rubocop:enable Rails/SkipsModelValidations
-    head :created
+    pull_request = PullRequest.find_or_create_by(number: pull_params[:number])
+    if pull_request.update!(pull_params)
+      head :created
+    else
+      head :unprocessable_entity
+    end
   end
 
   private

--- a/app/controllers/api/pulls_controller.rb
+++ b/app/controllers/api/pulls_controller.rb
@@ -4,7 +4,7 @@ class API::PullsController < APIController
   before_action :authenticate, only: [:create]
 
   def create
-    pull_request = PullRequest.upsert(pull_params, unique_by: :number)
+    PullRequest.upsert(pull_params, unique_by: :number)
     head :created
   end
 

--- a/app/controllers/api/pulls_controller.rb
+++ b/app/controllers/api/pulls_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class API::PullsController < ApplicationController
-  protect_from_forgery except: :create
+class API::PullsController < APIController
   before_action :authenticate, only: [:create]
 
   def create

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class APIController < ApplicationController
+  protect_from_forgery except: :create
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class HomeController < ApplicationController
-  require 'json'
   require 'octokit'
 
   def index

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class HomeController < ApplicationController
-  require 'octokit'
-
   def index
     @users = User.order('LOWER(name)')
   end

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from '@hotwired/stimulus'
-
-export default class extends Controller {
-  connect () {
-    this.element.textContent = 'Hello World!'
-  }
-}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
 
   get "/auth/:provider/callback" => "sessions#create"
   get "/auth/failure" => "sessions#failure"
-  resource :retirements, only: %i(create)
+  resource :retirements, only: [:create]
 end


### PR DESCRIPTION
[11/3(木)](https://bootcamp.fjord.jp/products/14246#comment_114402)にいただいたコードレビューに基づく修正を行いました。

# やったこと
- `routes.rb`の記法を`[]`に統一しました。
- `require 'json'`と`require 'octokit'`は、そもそも使っていなかったので記述を削除しました。
  - `octokit`は使っていないのでGemfileから削除し、アンインストールしました。
- `api/issues_controller`と`api/pulls_controller`の両方で行っている共通の処理を、APIControllerを作成して書いて、そちらを継承するようにしました。
- `pull_request`のレコードのcreateまたはupdateを行う処理を、`upsert`メソッドに書き換えました。
- `hello_controller.js`は不要のため削除しました。

## upsertメソッドはrubocopでは非推奨のようです
> `find_or_create_by`と`update`を使うのであれば`upsert`を使うのがいいかもです〜

と仰っていただいたのですが、使用したところrubocopから
> C: Rails/SkipsModelValidations: Avoid using upsert because it skips validations.

と警告されました。バリデーションをスキップし、有効性に関係なくオブジェクトをDBに保存するため、非推奨のようです。
一旦ご指摘いただいた通りに`upsert`を使い、警告をコメントで無効化しました。

- 参考
  - [クラス: RuboCop::Cop::Rails::SkipsModelValidations — rubocop のドキュメント \(0\.50\.0\)](https://www.rubydoc.info/gems/rubocop/0.50.0/RuboCop/Cop/Rails/SkipsModelValidations)
  - [Active Record Validations — Ruby on Rails Guides](https://guides.rubyonrails.org/active_record_validations.html#skipping-validations) 