### PR TITLE
退会したuserが別端末でアクセスした際にsessionが残っている場合、sessionを削除し、current_userの戻り値をnilにした

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,9 +17,10 @@ class ApplicationController < ActionController::Base
     return unless session[:user_id]
 
     @current_user ||= User.find_by(id: session[:user_id])
-    unless @current_user
-      session[:user_id] = nil
-    end
-    @current_user
+  # 退会したuserが別端末でアクセスした際にsessionが残っている場合、sessionを削除し、current_userの戻り値をnilにする
+  rescue AcitveRecord::RecordNotFound
+    reset_session
+
+    nil
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,16 +6,20 @@ class ApplicationController < ActionController::Base
   private
 
   def logged_in?
-    !!session[:user_id]
+    !!current_user
   end
 
   def not_logged_in?
-    !!!session[:user_id]
+    !logged_in?
   end
 
   def current_user
     return unless session[:user_id]
 
-    @current_user ||= User.find(session[:user_id])
+    @current_user ||= User.find_by(id: session[:user_id])
+    unless @current_user
+      session[:user_id] = nil
+    end
+    @current_user
   end
 end


### PR DESCRIPTION
## issue
- #191 

## 原因
- このサービスはトップページしか無く、ログインしているか否かで表示するものを変えている。ログイン時に表示するログインユーザーの情報は、自作した`current_user`メソッドを使って表示させている。
```ruby
# 変更前
  def current_user
    return unless session[:user_id] # sessionが残っているのでここで処理を抜けない

    @current_user ||= User.find(session[:user_id]) #191 残ってるsessionを元にレコードを探しても、退会していて存在しないのでエラーになる
  end
```
- `current_user`メソッドは、残っているセッションを元にUserモデルを検索して、`@current_user`に代入する。
- 端末Aで退会した時に、端末Bにセッションが残っていると、セッションは残っているので`return`の処理で抜けずに`@current_user ||= User.find(session[:user_id])`の処理が実行されてしまい、該当のUserモデルのレコードは削除されてしまっているので、
```bash
ActionView::Template::Error (Couldn't find User with 'id'=88):
```
のようなエラーが起こってしまう。


### 参考
https://discord.com/channels/715806612824260640/856415098834780189/1039435714800136232

## 解決法

- 該当のレコードがない時(`AcitveRecord::RecordNotFound`)、
  - セッション削除
  - `current_user`メソッドの戻り値を`nil`にする

- `find`から`find_by`にした理由
  - 引数で渡した条件のレコードが見つからなかった時の戻り値が違う。
  - `find`:エラーが返る。`ActiveRecord::RecordNotFound: Couldn't find User with 'id'=3`
  - `find_by`:`nil`が返ってくる



